### PR TITLE
8000端口渲染时因没有加doctype，导致antd的icon样式不垂直居中

### DIFF
--- a/example/ssr-with-ts/package.json
+++ b/example/ssr-with-ts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssr-with-ts",
-  "version": "2.0.5",
+  "version": "2.0.6",
   "description": "ykfe",
   "dependencies": {
     "egg-scripts": "^2.10.0",
@@ -26,7 +26,6 @@
     "cross-env": "^5.2.0",
     "css-hot-loader": "^1.4.3",
     "css-loader": "1.0.0",
-    "css-modules-require-hook": "^4.2.3",
     "egg-proxy": "^1.1.0",
     "file-loader": "2.0.0",
     "less": "^3.9.0",
@@ -41,8 +40,6 @@
     "react-dev-utils": "^8.0.0",
     "rimraf": "^2.6.3",
     "terser-webpack-plugin": "^1.2.0",
-    "ts-node": "^8.3.0",
-    "tslib": "^1.8.1",
     "tslint": "^5.11.0",
     "tslint-config-standard": "^8.0.1",
     "typescript": "^3.5.0",

--- a/example/ssr-with-ts/web/entry.tsx
+++ b/example/ssr-with-ts/web/entry.tsx
@@ -1,14 +1,14 @@
 import React from 'react'
 import ReactDOM from 'react-dom'
 import { BrowserRouter, StaticRouter, Route } from 'react-router-dom'
-import defaultLayout from './layout'
 import { Context } from 'midway'
-
 import { RouteItem } from './interface/route'
+import defaultLayout from './layout'
+
 const { routes } = require('../config/config.ssr')
 const { getWrappedComponent, getComponent } = require('ykfe-utils')
-const clientRender = async (): Promise<void> => {
 
+const clientRender = async (): Promise<void> => {
   // 客户端渲染||hydrate
   ReactDOM[window.__USE_SSR__ ? 'hydrate' : 'render'](
     <BrowserRouter>
@@ -16,7 +16,7 @@ const clientRender = async (): Promise<void> => {
         // 使用高阶组件getWrappedComponent使得csr首次进入页面以及csr/ssr切换路由时调用getInitialProps
         routes.map((item: RouteItem) => {
           const ActiveComponent = item.Component()
-          const Layout  = ActiveComponent.Layout || defaultLayout 
+          const Layout = ActiveComponent.Layout || defaultLayout
           const WrappedComponent = getWrappedComponent(ActiveComponent)
           return <Route exact={item.exact} key={item.path} path={item.path} render={() => {
             return <Layout><WrappedComponent /></Layout>

--- a/example/ssr-with-ts/web/layout/index.tsx
+++ b/example/ssr-with-ts/web/layout/index.tsx
@@ -13,14 +13,12 @@ const commonNode = (props: LayoutProps) => (
     : null
 )
 
-
-
 interface LayoutProps {
   layoutData?: Context,
   children?: JSX.Element | null
 }
 
-const Layout: SFC<LayoutProps> = (props:LayoutProps) : JSX.Element | null => {
+const Layout: SFC<LayoutProps> = (props: LayoutProps): JSX.Element | null => {
   if (__isBrowser__) {
     return commonNode(props)
   } else {
@@ -34,7 +32,7 @@ const Layout: SFC<LayoutProps> = (props:LayoutProps) : JSX.Element | null => {
           <meta name='theme-color' content='#000000' />
           <title>React App</title>
           {
-            injectCss && injectCss.map((item: string) => <link rel='stylesheet' href={item} key={item} />)
+             injectCss && injectCss.map((item: string) => <link rel='stylesheet' href={item} key={item} />)
           }
         </head>
         <body>

--- a/example/ssr-with-ts/web/page/news/index.tsx
+++ b/example/ssr-with-ts/web/page/news/index.tsx
@@ -1,9 +1,9 @@
 import React from 'react'
 import './index.less'
 interface MockData {
-  [index: number]: string;
+  [index: number]: string
 }
-const mockData:MockData = {
+const mockData: MockData = {
   1: `Racket-on-Chez continues to improve. Snapshot builds are currently available at pre.racket-lang.org, and we expect that Racket-on-Chez will be included as a download option in the next release.`,
   2: `This means anyone with more than three devices connected doesn't have to worry right this instant. That will change, however, when it comes time to replace one of your current devices or if you add another device to your collection. At that point, you will have to make a decision.`,
   3: `World's most mysterious text is finally cracked: Bristol academic deciphers lost language of 600-year-old Voynich manuscript to reveal astrological sex tips, herbal remedies and other pagan beliefs`,

--- a/example/ssr-with-ts/web/tsconfig.json
+++ b/example/ssr-with-ts/web/tsconfig.json
@@ -1,5 +1,5 @@
+// 此文件仅用于本地开发配置IDE在检查web下ts语法时的规则，不用于实际构建
 {
-  "info":"此文件仅用于配置IDE在检查web下ts语法时的规则，不用于实际构建",
   "compilerOptions": {
     "esModuleInterop": true,
     "lib": [
@@ -23,6 +23,5 @@
     "stripInternal": true,
     "target": "es5",
     "jsx": "react"
-  },
-  
+  }
 }

--- a/package.json
+++ b/package.json
@@ -76,7 +76,7 @@
     "ts-jest": "^24.0.2",
     "tslint": "^5.17.0",
     "tslint-config-standard": "^8.0.1",
-    "typescript": "^3.5.3",
+    "typescript": "^3.7.2",
     "vuepress": "^0.14.8"
   },
   "dependencies": {}

--- a/packages/yk-cli/src/clientRender.ts
+++ b/packages/yk-cli/src/clientRender.ts
@@ -36,7 +36,7 @@ const dev = async (argv?: Argv) => {
     headers: {
       'access-control-allow-origin': '*'
     },
-    before (app: any) {
+    before(app: any) {
       app.get('/', async (req: any, res: any) => {
         const stream = await renderLayout()
         stream.pipe(res, { end: false })
@@ -45,8 +45,9 @@ const dev = async (argv?: Argv) => {
         })
       })
     },
-    after (app: any) {
+    after(app: any) {
       app.get(/^\//, async (req: any, res: any) => {
+        res.write('<!DOCTYPE html>')
         const stream = await renderLayout()
         stream.pipe(res, { end: false })
         stream.on('end', () => {


### PR DESCRIPTION
在webpack-dev-server的after里，增加了doctype。