### PR TITLE
perf: 优化服务端dva，减小返回数据，优化速度

### DIFF
--- a/example/ssr-with-dva/web/dvaForServer.js
+++ b/example/ssr-with-dva/web/dvaForServer.js
@@ -1,0 +1,31 @@
+import dva from 'dva';
+import models from './models';
+
+let dvaForServer;
+const originModelsData = {}
+
+const initDvaForServer = (options) => {
+    if (dvaForServer) {
+        dvaForServer._store.dispatch({ type: 'SEVERRESET' });
+        return dvaT
+    }
+    const app = dva({
+        ...options,
+        onReducer: reducer => {
+            return (state, action) => {
+                const newState = action.type === 'SEVERRESET' ? originModelsData : reducer(state, action);
+                return { ...newState, routing: newState.routing };
+            };
+        }
+    })
+    models.forEach((m) => {
+        originModelsData[`${m.namespace}`] = m.state;
+        app.model(m)
+    })
+    app.router(() => { })
+    app.start()
+    dvaForServer = app
+    return app
+}
+
+export default initDvaForServer;

--- a/example/ssr-with-dva/web/entry.js
+++ b/example/ssr-with-dva/web/entry.js
@@ -6,12 +6,13 @@ import { getWrappedComponent, getComponent } from 'ykfe-utils'
 import { createMemoryHistory, createBrowserHistory } from 'history'
 import { routes as Routes } from '../config/config.ssr'
 import defaultLayout from '@/layout'
-import models from './models'
+import models from './models';
+import initDvaForServer from './dvaForServer'
 
 const initDva = (options) => {
   const app = dva(options)
   models.forEach(m => app.model(m))
-  app.router(() => {})
+  app.router(() => { })
   app.start()
   return app
 }
@@ -49,7 +50,7 @@ const clientRender = () => {
 }
 
 const serverRender = async ctx => {
-  const app = initDva({
+  const app = initDvaForServer({
     history: createMemoryHistory({
       initialEntries: [ctx.req.url]
     })
@@ -58,9 +59,9 @@ const serverRender = async ctx => {
   ctx.store = store
   const ActiveComponent = getComponent(Routes, ctx.path)()
   const Layout = ActiveComponent.Layout || defaultLayout
-  ActiveComponent.getInitialProps ? await ActiveComponent.getInitialProps(ctx) : {} // eslint-disable-line
+  const initialState = ActiveComponent.getInitialProps ? await ActiveComponent.getInitialProps(ctx) : {} // eslint-disable-line
   const storeState = store.getState()
-  ctx.serverData = storeState
+  ctx.serverData = initialState
 
   app.router(() => (
     <StaticRouter location={ctx.req.url} context={storeState}>

--- a/example/ssr-with-dva/web/page/index/index.js
+++ b/example/ssr-with-dva/web/page/index/index.js
@@ -23,6 +23,8 @@ function Page (props) {
 
 Page.getInitialProps = async ({ store }) => {
   await store.dispatch({ type: 'page/getData' })
+  const { page } = store.getState();
+  return { page };
 }
 
 const mapStateToProps = (state) => ({


### PR DESCRIPTION
1.优化服务端dva，每个进程中只保留一份dva，不重复创建dva，减少dva创建带来的耗时，同时在首次创建dva时，保留一份赶紧的model中state数据，下次进来时通过注入一个全局reducer，触发action清空现有model数据，保持dva干净。
2.优化返回页面大小，减小带回来的数据量，只带当前页面所需的model数据，压缩页面大小，加载更快。
当model中effect越多时，dva创建的时间就越长，所以才有了上面的优化